### PR TITLE
Add Ant Farm simulator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ant Farm Simulator</title>
+<style>
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f2efe4;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 100vh;
+}
+
+header {
+    background-color: #6b4423;
+    color: #fff;
+    width: 100%;
+    padding: 10px;
+    text-align: center;
+}
+
+#controls {
+    margin: 10px;
+}
+
+canvas {
+    border: 2px solid #333;
+    background-color: #fff;
+}
+
+.stats {
+    margin-top: 5px;
+}
+
+button {
+    margin: 0 5px;
+    padding: 5px 10px;
+}
+</style>
+</head>
+<body>
+<header>
+    <h1>Ant Farm Simulator</h1>
+</header>
+<div id="controls">
+    <button id="resetBtn">Reset</button>
+    <button id="addAntBtn">Add Ant</button>
+    <span class="stats" id="population"></span>
+    <span class="stats" id="foodCount"></span>
+</div>
+<canvas id="farm" width="800" height="600"></canvas>
+<script>
+const canvas = document.getElementById('farm');
+const ctx = canvas.getContext('2d');
+const populationEl = document.getElementById('population');
+const foodEl = document.getElementById('foodCount');
+const resetBtn = document.getElementById('resetBtn');
+const addAntBtn = document.getElementById('addAntBtn');
+
+const NEST = { x: canvas.width / 2, y: canvas.height / 2, radius: 10 };
+let ants = [];
+let foods = [];
+let collected = 0;
+const ANT_SPEED = 1.5;
+
+class Ant {
+    constructor(x, y) {
+        this.x = x;
+        this.y = y;
+        this.angle = Math.random() * Math.PI * 2;
+        this.carrying = false;
+    }
+    move() {
+        if (this.carrying) {
+            // head towards nest
+            this.angle = Math.atan2(NEST.y - this.y, NEST.x - this.x);
+        } else {
+            // wander
+            this.angle += (Math.random() - 0.5) * 0.2;
+        }
+        this.x += Math.cos(this.angle) * ANT_SPEED;
+        this.y += Math.sin(this.angle) * ANT_SPEED;
+        // keep in bounds
+        this.x = Math.max(0, Math.min(canvas.width, this.x));
+        this.y = Math.max(0, Math.min(canvas.height, this.y));
+    }
+    draw() {
+        ctx.fillStyle = this.carrying ? 'orange' : 'black';
+        ctx.beginPath();
+        ctx.arc(this.x, this.y, 3, 0, Math.PI * 2);
+        ctx.fill();
+    }
+}
+
+class Food {
+    constructor(x, y) {
+        this.x = x;
+        this.y = y;
+        this.radius = 4;
+    }
+    draw() {
+        ctx.fillStyle = 'green';
+        ctx.beginPath();
+        ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+        ctx.fill();
+    }
+}
+
+function initAnts(n = 5) {
+    ants = [];
+    for (let i = 0; i < n; i++) {
+        ants.push(new Ant(NEST.x + Math.random()*20-10, NEST.y + Math.random()*20-10));
+    }
+}
+
+function resetFarm() {
+    initAnts();
+    foods = [];
+    collected = 0;
+}
+
+function addFood(x, y) {
+    foods.push(new Food(x, y));
+}
+
+function addAnt() {
+    ants.push(new Ant(NEST.x, NEST.y));
+}
+
+function update() {
+    ctx.clearRect(0,0,canvas.width, canvas.height);
+    // draw nest
+    ctx.fillStyle = '#c2a368';
+    ctx.beginPath();
+    ctx.arc(NEST.x, NEST.y, NEST.radius, 0, Math.PI*2);
+    ctx.fill();
+
+    // draw foods
+    for (const food of foods) {
+        food.draw();
+    }
+
+    for (const ant of ants) {
+        ant.move();
+        // check collisions with food
+        if (!ant.carrying) {
+            for (let i = 0; i < foods.length; i++) {
+                const food = foods[i];
+                const dx = ant.x - food.x;
+                const dy = ant.y - food.y;
+                const dist = Math.sqrt(dx*dx+dy*dy);
+                if (dist < 5) {
+                    ant.carrying = true;
+                    foods.splice(i,1);
+                    break;
+                }
+            }
+        } else {
+            // check if at nest
+            const dx = ant.x - NEST.x;
+            const dy = ant.y - NEST.y;
+            const dist = Math.sqrt(dx*dx+dy*dy);
+            if (dist < NEST.radius) {
+                ant.carrying = false;
+                collected++;
+                // spawn new ant for growth
+                ants.push(new Ant(NEST.x, NEST.y));
+            }
+        }
+        ant.draw();
+    }
+
+    populationEl.textContent = 'Population: ' + ants.length;
+    foodEl.textContent = 'Food Collected: ' + collected;
+
+    requestAnimationFrame(update);
+}
+
+canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    addFood(x, y);
+});
+
+resetBtn.addEventListener('click', resetFarm);
+addAntBtn.addEventListener('click', addAnt);
+
+resetFarm();
+update();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `index.html` single-page web app
- implement canvas-based Ant Farm simulator with interactive food placement
- include controls to reset farm or add more ants and show population/food count

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68598a2430a48325ae23d6af62460d2f